### PR TITLE
sha256 hash RequestMissing signables before signing

### DIFF
--- a/build/go/community/helpers.go
+++ b/build/go/community/helpers.go
@@ -65,11 +65,10 @@ func (a *Ack) Sign(key *ecdsa.PrivateKey) ([]byte, error) {
 
 func (rm *RequestMissing) Signable() []byte {
 	seqBytes := uint64ToBytes(rm.Sequence)
+	preImage := appendMultiple(rm.Identifier, seqBytes)
+	hsh := sha256.Sum256(preImage)
 
-	return appendMultiple(
-		rm.Identifier,
-		seqBytes,
-	)
+	return hsh[:]
 }
 
 func (rm *RequestMissing) Sign(key *ecdsa.PrivateKey) ([]byte, error) {

--- a/build/go/community/helpers_test.go
+++ b/build/go/community/helpers_test.go
@@ -1,15 +1,22 @@
 package community
 
 import (
+	"crypto/ecdsa"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 )
 
-func TestSignEnvelope(t *testing.T) {
+func generateKey(t *testing.T) *ecdsa.PrivateKey {
 	key, err := crypto.GenerateKey()
 	require.Nil(t, err)
+
+	return key
+}
+
+func TestSignEnvelope(t *testing.T) {
+	key := generateKey(t)
 
 	e := &Envelope{
 		To:       []byte("did:test:bob"),
@@ -18,14 +25,13 @@ func TestSignEnvelope(t *testing.T) {
 		Sequence: 0,
 	}
 
-	_, err = e.Sign(key)
+	_, err := e.Sign(key)
 	require.Nil(t, err)
 	require.NotNil(t, e.Signature)
 }
 
 func TestSignAck(t *testing.T) {
-	key, err := crypto.GenerateKey()
-	require.Nil(t, err)
+	key := generateKey(t)
 
 	e := &Envelope{
 		To:       []byte("did:test:bob"),
@@ -36,7 +42,20 @@ func TestSignAck(t *testing.T) {
 	e.SetID()
 
 	ack := AckFromEnv(e)
-	_, err = ack.Sign(key)
+	_, err := ack.Sign(key)
 	require.Nil(t, err)
 	require.NotNil(t, ack.Signature)
+}
+
+func TestSignRequestMissing(t *testing.T) {
+	key := generateKey(t)
+
+	req := &RequestMissing{
+		Sequence:   5,
+		Identifier: []byte("id"),
+	}
+
+	_, err := req.Sign(key)
+	require.Nil(t, err)
+	require.NotNil(t, req.Signature)
 }


### PR DESCRIPTION
I found a bug in community that I traced back to us not hashing the `RequestMissing.Signable()` return value. That made go-ethereum/crypto complain about it's input not being exactly 32 bytes.