### PR TITLE
bump js version to 2.0.2

### DIFF
--- a/build/js/package-lock.json
+++ b/build/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-messages",
-  "version": "0.5.0-rc6",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/build/js/package.json
+++ b/build/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tupelo-messages",
-  "version": "0.5.0-rc6",
+  "version": "2.0.2",
   "description": "Tupelo JavaScript messages implementation",
   "repository": {
     "type": "git",


### PR DESCRIPTION
need to publish something to npm for tupelo-wasm-sdk to use in master --- `v0.6.0` seems to be consistent with our version bumps, but it is technically a breaking change so a major bump could be argued.