### PR TITLE
Fix v1 no prefix

### DIFF
--- a/src/bridge/bridge.proto
+++ b/src/bridge/bridge.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package v1bridge;
+package bridge;
 
 option go_package = "github.com/quorumcontrol/messages/build/go/bridge";
 

--- a/src/community/community.proto
+++ b/src/community/community.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 option go_package = "github.com/quorumcontrol/messages/build/go/community";
 
-package v1community;
+package community;
 
 message Envelope {
     bytes id = 1; // sha256(to + from + payload + sequence)

--- a/src/config/config.proto
+++ b/src/config/config.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package v1config;
+package config;
 
 option go_package = "github.com/quorumcontrol/messages/build/go/config";
 

--- a/src/services/services.proto
+++ b/src/services/services.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package v1services;
+package services;
 
 option go_package = "github.com/quorumcontrol/messages/build/go/services";
 
@@ -39,7 +39,7 @@ message Credentials {
 
 message SerializableChainTree {
   repeated bytes dag = 1;
-  map<string, v1signatures.Signature> signatures = 2;
+  map<string, signatures.Signature> signatures = 2;
   // tip is a string because of compatability with the javascript layer
   // which cannot seem to parse a golang cid.Bytes()
   string tip = 3;
@@ -140,7 +140,7 @@ message SetOwnerRequest {
   string chain_id = 2;
   string key_addr = 3;
   // index 4 is a deleted key and intentionally omitted
-  v1transactions.SetOwnershipPayload payload = 5;
+  transactions.SetOwnershipPayload payload = 5;
 }
 
 message SetOwnerResponse {
@@ -152,7 +152,7 @@ message SetDataRequest {
   string chain_id = 2;
   string key_addr = 3;
   // indexes 4 and 5 are deleted keys and intentionally omitted
-  v1transactions.SetDataPayload payload = 6;
+  transactions.SetDataPayload payload = 6;
 }
 
 message SetDataResponse {
@@ -182,7 +182,7 @@ message EstablishTokenRequest {
   string chain_id = 2;
   string key_addr = 3;
   // indexes 4 and 5 are deleted keys and intentionally omitted
-  v1transactions.EstablishTokenPayload payload = 6;
+  transactions.EstablishTokenPayload payload = 6;
 }
 
 message EstablishTokenResponse {
@@ -194,7 +194,7 @@ message MintTokenRequest {
   string chain_id = 2;
   string key_addr = 3;
   // indexes 4 and 5 are deleted keys and intentionally omitted
-  v1transactions.MintTokenPayload payload = 6;
+  transactions.MintTokenPayload payload = 6;
 }
 
 message MintTokenResponse {
@@ -208,7 +208,7 @@ message SendTokenRequest {
   string token_name = 4;
   string destination_chain_id = 5;
   uint64 amount = 6;
-  v1transactions.SendTokenPayload payload = 7;
+  transactions.SendTokenPayload payload = 7;
 }
 
 message SendTokenResponse {
@@ -239,7 +239,7 @@ message PlayTransactionsRequest {
   Credentials creds = 1;
   string chain_id = 2;
   string key_addr = 3;
-  repeated v1transactions.Transaction transactions = 4;
+  repeated transactions.Transaction transactions = 4;
 }
 
 message PlayTransactionsResponse {

--- a/src/signatures/signatures.proto
+++ b/src/signatures/signatures.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package v1signatures;
+package signatures;
 
 option go_package = "github.com/quorumcontrol/messages/build/go/signatures";
 

--- a/src/transactions/transactions.proto
+++ b/src/transactions/transactions.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package v1transactions;
+package transactions;
 
 option go_package = "github.com/quorumcontrol/messages/build/go/transactions";
 
@@ -38,22 +38,22 @@ message SendTokenPayload{
 message ReceiveTokenPayload{
   string send_token_transaction_id = 1;
   bytes tip = 2;
-  v1signatures.Signature signature = 3;
+  signatures.Signature signature = 3;
   repeated bytes Leaves = 4;
 }
 
 message TokenPayload {
   string transaction_id = 1;
   string tip = 2;
-  v1signatures.Signature signature = 3;
+  signatures.Signature signature = 3;
   repeated bytes leaves = 4;
 }
 
 message StakePayload{
   string group_id = 1;
   uint64 amount = 2;
-  v1signatures.PublicKey dst_key = 3;
-  v1signatures.PublicKey ver_key = 4;
+  signatures.PublicKey dst_key = 3;
+  signatures.PublicKey ver_key = 4;
 }
 
 message Transaction{


### PR DESCRIPTION
Old code expects no prefix, so let's remove it from v1 so that code gets the messages it expects. I'll add a v2 prefix to the v2 code so we can still mix them both in the same project (e.g. gossip3to4 dark traffic testing).

We're currently thinking of releasing this as version 1.1.0 once merged to the v1 branch.

H/T to Topper for figuring this out. 🤡 👞 for me.