### PR TITLE
Add v2 prefix to proto package names

### DIFF
--- a/src/bridge/bridge.proto
+++ b/src/bridge/bridge.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package bridge;
+package v2bridge;
 
 option go_package = "github.com/quorumcontrol/messages/v2/build/go/bridge";
 

--- a/src/community/community.proto
+++ b/src/community/community.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 option go_package = "github.com/quorumcontrol/messages/v2/build/go/community";
 
-package community;
+package v2community;
 
 message Envelope {
     bytes id = 1; // sha256(to + from + payload + sequence)

--- a/src/config/config.proto
+++ b/src/config/config.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package config;
+package v2config;
 
 option go_package = "github.com/quorumcontrol/messages/v2/build/go/config";
 

--- a/src/services/services.proto
+++ b/src/services/services.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package services;
+package v2services;
 
 option go_package = "github.com/quorumcontrol/messages/v2/build/go/services";
 
@@ -39,7 +39,7 @@ message Credentials {
 
 message SerializableChainTree {
   repeated bytes dag = 1;
-  map<string, signatures.Signature> signatures = 2;
+  map<string, v2signatures.Signature> signatures = 2;
   // tip is a string because of compatability with the javascript layer
   // which cannot seem to parse a golang cid.Bytes()
   string tip = 3;
@@ -140,7 +140,7 @@ message SetOwnerRequest {
   string chain_id = 2;
   string key_addr = 3;
   // index 4 is a deleted key and intentionally omitted
-  transactions.SetOwnershipPayload payload = 5;
+  v2transactions.SetOwnershipPayload payload = 5;
 }
 
 message SetOwnerResponse {
@@ -152,7 +152,7 @@ message SetDataRequest {
   string chain_id = 2;
   string key_addr = 3;
   // indexes 4 and 5 are deleted keys and intentionally omitted
-  transactions.SetDataPayload payload = 6;
+  v2transactions.SetDataPayload payload = 6;
 }
 
 message SetDataResponse {
@@ -182,7 +182,7 @@ message EstablishTokenRequest {
   string chain_id = 2;
   string key_addr = 3;
   // indexes 4 and 5 are deleted keys and intentionally omitted
-  transactions.EstablishTokenPayload payload = 6;
+  v2transactions.EstablishTokenPayload payload = 6;
 }
 
 message EstablishTokenResponse {
@@ -194,7 +194,7 @@ message MintTokenRequest {
   string chain_id = 2;
   string key_addr = 3;
   // indexes 4 and 5 are deleted keys and intentionally omitted
-  transactions.MintTokenPayload payload = 6;
+  v2transactions.MintTokenPayload payload = 6;
 }
 
 message MintTokenResponse {
@@ -208,7 +208,7 @@ message SendTokenRequest {
   string token_name = 4;
   string destination_chain_id = 5;
   uint64 amount = 6;
-  transactions.SendTokenPayload payload = 7;
+  v2transactions.SendTokenPayload payload = 7;
 }
 
 message SendTokenResponse {
@@ -239,7 +239,7 @@ message PlayTransactionsRequest {
   Credentials creds = 1;
   string chain_id = 2;
   string key_addr = 3;
-  repeated transactions.Transaction transactions = 4;
+  repeated v2transactions.Transaction transactions = 4;
 }
 
 message PlayTransactionsResponse {

--- a/src/signatures/signatures.proto
+++ b/src/signatures/signatures.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package signatures;
+package v2signatures;
 
 option go_package = "github.com/quorumcontrol/messages/v2/build/go/signatures";
 

--- a/src/transactions/transactions.proto
+++ b/src/transactions/transactions.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package transactions;
+package v2transactions;
 
 option go_package = "github.com/quorumcontrol/messages/v2/build/go/transactions";
 
@@ -38,22 +38,22 @@ message SendTokenPayload{
 message ReceiveTokenPayload{
   string send_token_transaction_id = 1;
   bytes tip = 2;
-  signatures.TreeState tree_state = 3;
+  v2signatures.TreeState tree_state = 3;
   repeated bytes Leaves = 4;
 }
 
 message TokenPayload {
   string transaction_id = 1;
   string tip = 2;
-  signatures.TreeState tree_state = 3;
+  v2signatures.TreeState tree_state = 3;
   repeated bytes leaves = 4;
 }
 
 message StakePayload{
   string group_id = 1;
   uint64 amount = 2;
-  signatures.PublicKey dst_key = 3;
-  signatures.PublicKey ver_key = 4;
+  v2signatures.PublicKey dst_key = 3;
+  v2signatures.PublicKey ver_key = 4;
 }
 
 message Transaction{


### PR DESCRIPTION
Adds `v2` prefixes to protobuf package names so they can coexist in the same project with the v1 messages. We need this for gossip3to4 dark traffic testing. Reverses my original approach of adding `v1` prefixes, which was backwards and made the old v1-expecting code inadvertently switch to using v2 messages.

Counterpart to #23.