### PR TITLE
Eliminate a harmless but annoying error message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,8 @@ FIRSTGOPATH = $(firstword $(subst :, ,$(GOPATH)))
 
 GOGO_PROTOBUF_VERSION = $(shell grep github.com/gogo/protobuf go.mod | awk '{print $$2}')
 
-NODE_PROTOC_TS_PLUGIN = $(shell cd build/js && npm bin)/protoc-gen-ts
-
 NPM_BIN = $(shell cd build/js && npm bin)
+NODE_PROTOC_TS_PLUGIN = $(NPM_BIN)/protoc-gen-ts
 
 $(NODE_PROTOC_TS_PLUGIN):
 	cd build/js && npm install --only=dev


### PR DESCRIPTION
This gets rid of a harmless but worrisome `protoc: not found` error in
environments where there is no protoc installed in PATH (like CI).

(I merged the primary PR for this already but realized I still had this local un-pushed commit.)